### PR TITLE
Fix syntax warning

### DIFF
--- a/RSSReader/ViewController.swift
+++ b/RSSReader/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class ViewController: UITableViewController, MWFeedParserDelegate {
     
-    var items = MWFeedItem[]()
+    var items = [MWFeedItem]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,7 +36,7 @@ class ViewController: UITableViewController, MWFeedParserDelegate {
     
     func feedParserDidStart(parser: MWFeedParser) {
         SVProgressHUD.show()
-        self.items = MWFeedItem[]()
+        self.items = [MWFeedItem]()
     }
 
     func feedParserDidFinish(parser: MWFeedParser) {


### PR DESCRIPTION
Fix Swift syntax warning: 
"Array types are now written with the brackets around the element type"
